### PR TITLE
Change ruby version to 3.2.2

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,7 @@
 source "https://rubygems.org"
 git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
-ruby "3.1.3"
+ruby "3.2.2"
 
 # Bundle edge Rails instead: gem "rails", github: "rails/rails", branch: "main"
 gem "rails", "~> 7.0.7", ">= 7.0.7.2"


### PR DESCRIPTION
### What does this PR do?
It changes the ruby version of the project from 3.1.3 to 3.2.2

### Any background context you want to provide?
Change was done to unify the ruby version for the team

### Are there any breaking changes?
Yes, the ruby version change is a breaking change